### PR TITLE
Support  TCMalloc

### DIFF
--- a/impl.nix
+++ b/impl.nix
@@ -13,6 +13,7 @@ let
       xorg.libXv
       xorg.libXrandr
       zlib
+      gperftools
       
       # for xformers
       gcc
@@ -37,6 +38,7 @@ pkgs.mkShell rec {
         libGLU libGL
         glib
       ];
+    LD_PRELOAD = "${pkgs.gperftools}/lib/libtcmalloc.so";
     LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
     CUDA_PATH = pkgs.lib.optionalString isCUDA pkgs.cudatoolkit;
     EXTRA_LDFLAGS = pkgs.lib.optionalString isCUDA "-L${pkgs.linuxPackages.nvidia_x11}/lib";


### PR DESCRIPTION
Add support for gperftools, which enables TCMalloc, providing marginally better performance and eliminating red text in the startup output, thereby relieving OCD-induced stress for the user.