### PR TITLE
Fix missing libzstd.so.1 when using torch 2.5.1+rocm6.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672350804,
-        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/impl.nix
+++ b/impl.nix
@@ -37,6 +37,7 @@ pkgs.mkShell rec {
         procps gnumake util-linux m4 gperf unzip
         libGLU libGL
         glib
+        zstd
       ];
     LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
     CUDA_PATH = pkgs.lib.optionalString (variant == "CUDA") pkgs.cudatoolkit;


### PR DESCRIPTION
I use this flake to run ComfyUI with my AMD GPU, requiring the ROCm version of PyTorch (currently `2.5.1+rocm6.1`) as outlined in the [README](https://github.com/comfyanonymous/ComfyUI?tab=readme-ov-file#amd-gpus-linux-only). Running ComfyUI with this setup will produce the following error:
```
(venv)
[halcyon@ikigai:~/ai/ComfyUI]$ HSA_OVERRIDE_GFX_VERSION=10.3.0 python main.py
Traceback (most recent call last):
  File "/home/halcyon/ai/ComfyUI/main.py", line 88, in <module>
    import comfy.utils
  File "/home/halcyon/ai/ComfyUI/comfy/utils.py", line 20, in <module>
    import torch
  File "/home/halcyon/ai/ComfyUI/venv/lib/python3.10/site-packages/torch/__init__.py", line 367, in <module>
    from torch._C import *  # noqa: F403
ImportError: libzstd.so.1: cannot open shared object file: No such file or directory
```

ComfyUI works fine after adding `zstd` to the `NIX_LD_LIBRARY_PATH`.

<details>
<summary>Edit: Image proof</summary>

![image](https://github.com/user-attachments/assets/ea33a515-7133-4991-998c-4a24852e0466)

</details>
